### PR TITLE
Switch to get() on dict to check for deprecated_port key

### DIFF
--- a/server/server.py
+++ b/server/server.py
@@ -99,7 +99,7 @@ def log_deprecated_port(f):
             log.error('Failed to parse request data')
             ok = False
             hostname = request.remote_addr
-        if app.config['deprecated_port']:
+        if app.config.get('deprecated_port'):
             log.warn('Host {} connected to deprecated port', hostname)
             if ok:
                 if open_issue(hostname, issue_name):


### PR DESCRIPTION
Server crashes with a KeyError if app.config['deprecated_port'] is not set, so replacing it with a call to the .get() method on the dict.