### PR TITLE
Support python 3.9

### DIFF
--- a/client/collect.py
+++ b/client/collect.py
@@ -145,7 +145,7 @@ def run_dir(dir_path, parse_output=True, delete_after_success=False,
             run_file(*args, **kwargs)
     for thread in threads:
         thread.join(timeout=thread_timeout)
-        if thread.isAlive():
+        if thread.is_alive():
             log.error("Timeout executing {}", thread.name)
     return results
 


### PR DESCRIPTION
isAlive has been deprecated for years, and removed in python 3.9.
is_alive has existed since python 2.6 (https://docs.python.org/2/library/threading.html#threading.Thread.isAlive), and as PenguinDome already requires python >=3.5, this change is safe to make.