### PR TITLE
Allow mountpoint /efi to be unencrypted

### DIFF
--- a/client/plugins/hd_encryption.py
+++ b/client/plugins/hd_encryption.py
@@ -72,7 +72,7 @@ for mount in open('/proc/mounts'):
                                'device': device,
                                'encrypted': True}
         continue
-    if mountpoint in ('/boot', '/boot/efi'):
+    if mountpoint in ('/boot', '/boot/efi', '/efi'):
         continue
     if device.find(':') > -1 or device.startswith('//'):
         # Remote device


### PR DESCRIPTION
`/efi` is a replacement for `/boot/efi`, so it should be included in the list of mountpoints that are skipped over.
https://github.com/systemd/systemd/pull/3757#issuecomment-234290236