### PR TITLE
Support greetd and swaylock

### DIFF
--- a/client/plugins/screenlock.py
+++ b/client/plugins/screenlock.py
@@ -19,10 +19,10 @@ from tempfile import TemporaryFile
 from penguindome import cached_data
 from penguindome.client import get_logger
 import penguindome.json as json
-from penguindome.plugin_tools import find_x_users, DBusUser, process_dict_iter
+from penguindome.plugin_tools import find_x_users, find_greetd_users, DBusUser, process_dict_iter
 
 valid_lockers = (
-    'betterlockscreen', 'slock', 'i3lock', 'i3lock-fancy', 'i3lock-fancy-rapid'
+    'betterlockscreen', 'slock', 'i3lock', 'i3lock-fancy', 'i3lock-fancy-rapid', 'swaylock'
 )
 valid_lockers_re = re.compile(r'\b(?:' +
                               '|'.join(re.escape(l) for l in valid_lockers) +
@@ -144,10 +144,49 @@ def xidlehook_status(user, display):
     return None
 
 
-display_checkers = (gnome_xscreensaver_status, xautolock_status,
-                    xidlehook_status)
+def swayidle_status(user, seat):
+    procs = (p for p in process_dict_iter(
+        ('username', 'environ', 'exe', 'cmdline')) if p['username'] == user)
+    procs = (p for p in procs if p['environ'].get('XDG_SEAT', None) == seat)
+    procs = (p for p in procs if p['exe'].endswith('/swayidle'))
+    for proc in procs:
+        args = proc['cmdline']
+        timers = []
+        waits = False
+        before_sleep = False
+        try:
+            while args:
+                if args[0] == 'timeout':
+                    # syntax: timeout <timeout> <timeout command> [<resume> <resume command>]
+                    timers.append({
+                        'time': int(args[1]),
+                        'locker': args[2]
+                    })
+                    params = 5 if args[3] == 'resume' else 3
+                    del args[0:params]
+                elif args[0] == 'before_sleep' and valid_lockers_re.search(args[1]):
+                    # this makes sure the locker is called before the computer goes to sleep
+                    before_sleep = True
+                    del args[0:2]
+                elif args[0] == '-w':
+                    # this makes sure that the before_sleep command finishes before the computer sleeps
+                    waits = True
+                    args.pop(0)
+                else:
+                    args.pop(0)
+        except Exception:
+            continue
 
-user_displays = find_x_users()
+        for timer in timers:
+            if valid_lockers_re.search(timer['locker']):
+                return {'enabled': True, 'delay': timer['time']}
+    return None
+
+
+display_checkers = (gnome_xscreensaver_status, xautolock_status,
+                    xidlehook_status, swayidle_status)
+
+user_displays = find_x_users() + find_greetd_users()
 
 results = {}
 

--- a/penguindome/plugin_tools.py
+++ b/penguindome/plugin_tools.py
@@ -18,6 +18,7 @@ who_x_re = re.compile(r'(\S+)\s+.*\((:\d[^\)]*)\)')
 _who_x_users = None
 _xinit_users = None
 _x_users = None
+_greetd_users = None
 
 
 def find_who_x_users():
@@ -96,6 +97,27 @@ def find_x_users():
         return _x_users
     _x_users = list(set(find_who_x_users()) | set(find_xinit_users()))
     return _x_users
+
+
+def find_greetd_users():
+    """Return all users logged in via greetd
+
+    The list items are (username, $XDG_SEAT).
+    """
+    global _greetd_users
+    if _greetd_users is not None:
+        return _greetd_users
+
+    greets = [p for p in process_dict_iter(('exe', 'pid')) if p['exe'].endswith('/greetd')]
+    users = []
+    for p in process_dict_iter(('ppid', 'exe', 'username', 'environ')):
+        if not p['exe'].endswith('/greetd'):
+            greetd = any(x for x in greets if p['ppid'] == x['pid'])
+            seat = p['environ'].get('XDG_SEAT', None)
+            if greetd and seat:
+                users.append((p['username'], seat))
+    _greetd_users = users
+    return users
 
 
 class DBusUser(object):


### PR DESCRIPTION
This one is a little more involved than my other PRs and might need a little extra attention when reviewing.

`find_x_users` returns an empty array on my system, as I'm using wayland. greetd is the login manager I'm using, so I've added a `find_greetd_users` function which works in pretty much the same way as `find_xinit_users`, but for greetd rather than xinit.

It simply finds the greetd process, and then checks which user owns the child process of it which is running some other program.
wayland doesn't have `$DISPLAY`, but it does have `$XDG_SEAT` which is effectively the same thing for what its being used for here, so the function returns that instead.

Next `swayidle` is added as a display checker. `swayidle` allows for commands to be executed after a set amount of inactivity, similarly to `xidle`, however each timeout event specified is absolute rather than relative.

Finally adds `swaylock` as a valid locker, which works identically to `i3lock` which is already present, but for sway rather than i3.