### PR TITLE
Ignore ramfs when checking for HD encryption

### DIFF
--- a/client/plugins/hd_encryption.py
+++ b/client/plugins/hd_encryption.py
@@ -57,7 +57,7 @@ for mount in open('/proc/mounts'):
                   'efivarfs', 'fuse', 'fuse.gvfsd-fuse', 'fusectl',
                   'hugetlbfs', 'iso9660', 'mqueue', 'nfs', 'nsfs', 'overlay',
                   'proc',
-                  'pstore', 'rpc_pipefs', 'securityfs', 'selinuxfs',
+                  'pstore', 'ramfs', 'rpc_pipefs', 'securityfs', 'selinuxfs',
                   'squashfs', 'sysfs',
                   'tmpfs', 'tracefs', 'vboxsf'):
         continue


### PR DESCRIPTION
I have no idea why I have a ramfs on my system, and I can't even tell what it's doing / does. But penguindome is apparently not very happy with it.

From a quick googling, it looks like ramfs and tmpfs are effectively the same, except tmpfs fixes a few issues ramfs has when the system runs out of memory and can utilise swap. As far as security goes, ramfs actually appears to be more secure (and would suggest why some systemd-sysusers credentials store is using it on my system), as the data can't leave ram and end up on the disk via swap.

Penguindome already ignores tmpfs, so I can't see any reason to not also ignore ramfs?