### PR TITLE
Pin itsdangerous version

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -19,6 +19,6 @@ psutil==5.6.6
 pycryptodome==3.7.2
 python-daemon==2.2.4
 python-dateutil==2.7.5
-PyYAML==5.3.1
+PyYAML>=5.4
 requests==2.21.0
 stopit==1.1.2

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,9 +1,9 @@
 # Quantopian, Inc. licenses this file to you under the Apache License, Version
 # 2.0 (the "License"); you may not use this file except in compliance with the
 # License. You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -11,6 +11,7 @@
 # the License.
 
 Flask==1.0.2
+itsdangerous==2.0.1
 Logbook==1.4.3.post1
 -e git://github.com/quantopian/MongoDBProxy.git#egg=mongodbproxy
 passlib==1.7.1

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -19,6 +19,6 @@ pycryptodome==3.7.2
 pymongo==3.10.1
 python-dateutil==2.7.5
 pytz==2018.9
-PyYAML==5.3.1
+PyYAML>=5.4
 requests==2.21.0
 stopit==1.1.2


### PR DESCRIPTION
https://itsdangerous.palletsprojects.com/en/2.1.x/changes/#version-2-1-0

2.1.0 removes itsdangerous.json, which the ancient version of flask PenguinDome uses depends on.

Also bumps PyYAML to fix critical CVE. Tested locally and seems to be fine.